### PR TITLE
Save should truncate the file before writing

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -54,6 +54,7 @@ impl Todo {
         let f = std::fs::OpenOptions::new()
             .write(true)
             .create(true)
+            .truncate(true)
             .open("db.json")?;
         serde_json::to_writer_pretty(f, &self.map)?;
 


### PR DESCRIPTION
Save should truncate the file before writing, otherwise can happen that
the json file will be invalid.